### PR TITLE
update examples with correct apt upgrade command

### DIFF
--- a/examples/update-containerd.sh
+++ b/examples/update-containerd.sh
@@ -2,5 +2,5 @@
 # assumes run as root
 PATH=$PATH:/usr/local/sbin:/usr/sbin:/sbin
 DEBIAN_FRONTEND=noninteractive
-apt-get upgrade moby-containerd -y
+apt-get install --only-upgrade moby-containerd -y
 systemctl restart kubelet

--- a/examples/update-docker.sh
+++ b/examples/update-docker.sh
@@ -2,5 +2,5 @@
 # assumes run as root
 PATH=$PATH:/usr/local/sbin:/usr/sbin:/sbin
 DEBIAN_FRONTEND=noninteractive
-apt-get upgrade moby-engine -y
+apt-get install --only-upgrade moby-engine -y
 systemctl restart kubelet


### PR DESCRIPTION
This PR changes the CRI upgrade examples so that they use the correct, package-specific upgrade command.

Refer:

https://askubuntu.com/questions/44122/how-to-upgrade-a-single-package-using-apt-get