### PR TITLE
add --node-status-update-frequency example

### DIFF
--- a/examples/update-node-status-frequency.sh
+++ b/examples/update-node-status-frequency.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# assumes run as root
+sed -i "s|--node-status-update-frequency=10s|--node-status-update-frequency=1m|g" /etc/default/kubelet
+systemctl restart kubelet


### PR DESCRIPTION
This PR adds an example of how to change the `--node-status-update-frequency` kubelet configuration from `/etc/default/kubelet`.