### PR TITLE
use /var instead of /var/run

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ We encourage folks who want to play around with kustodian to share thoughts in t
 
 ## Node maintenance specification
 
-The kustodian daemon runs on each node in a Kubernetes cluster, and continually looks for the presence of a sentinel file on the node filesystem: `/var/run/maintenance-required`. When that file is detected on a node, that node's kustodian daemon waits until it can reserve an exclusive "single node maintenance lock", after which point it will reserve that lock, and then gracefully cordon + drain  that node.
+The kustodian daemon runs on each node in a Kubernetes cluster, and continually looks for the presence of a sentinel file on the node filesystem: `/var/maintenance-required`. When that file is detected on a node, that node's kustodian daemon waits until it can reserve an exclusive "single node maintenance lock", after which point it will reserve that lock, and then gracefully cordon + drain  that node.
 
-After the node is successfully cordoned + drained, the kustodian daemon then creates a new sentinel file: `/var/run/maintenance-in-progress`, which indicates to the node host OS that this Kubernetes node is in a maintenance state, and is not actively participating in the cluster.
+After the node is successfully cordoned + drained, the kustodian daemon then creates a new sentinel file: `/var/maintenance-in-progress`, which indicates to the node host OS that this Kubernetes node is in a maintenance state, and is not actively participating in the cluster.
 
-At this point, kustodian waits for the **non-existence** of the original sentinel file `/var/run/maintenance-required`, which indicates that node maintenance is complete. The sentinel file `/var/run/maintenance-in-progress` is then deleted, and the node is rejoined to the cluster via an uncordon operation.
+At this point, kustodian waits for the **non-existence** of the original sentinel file `/var/maintenance-required`, which indicates that node maintenance is complete. The sentinel file `/var/maintenance-in-progress` is then deleted, and the node is rejoined to the cluster via an uncordon operation.
 
 The kustodian daemon does the above continually on all nodes: the practical outcome is that for a given node maintenance operation meant to be performed on *all* nodes, kustodian only executes maintenance on one node at a time, and only after that node is able to be successfully cordoned + drained.
 
@@ -28,24 +28,24 @@ The above follows a sort of [pub sub pattern](https://en.wikipedia.org/wiki/Publ
 
 This decribes the behavior from the persepctive of the kustodian daemon. To describe the behavior from the perspective of implementing host OS maintenance across nodes in a cluster:
 
-1. A node maintenance script must register itself for maintenance by creating the `/var/run/maintenance-required` sentinel file.
-2. That script must then wait in a loop for the existence of a `/var/run/maintenance-in-progress` sentinel file, which indicates permission for the script to begin node maintenance.
-3. After the maintenance script has completed, and any appropriate node health validation has been performed, the script registers its completion by deleting the `/var/run/maintenance-required` sentinel file.
-  - If the operation of the maintenance script has failed, or produced undesired side effects, the script would purposefully *not* delete the `/var/run/maintenance-required` sentinel file on the host filesystem. Keeping that file around guarantees that this Kubernetes node will continue to be cordoned (not actively participating in the cluster); furthermore, it will guarantee that no other nodes will be negatively affected similarly (kustodian's "single node maintenance lock" will continue to be reserved by this node).
+1. A node maintenance script must register itself for maintenance by creating the `/var/maintenance-required` sentinel file.
+2. That script must then wait in a loop for the existence of a `/var/maintenance-in-progress` sentinel file, which indicates permission for the script to begin node maintenance.
+3. After the maintenance script has completed, and any appropriate node health validation has been performed, the script registers its completion by deleting the `/var/maintenance-required` sentinel file.
+  - If the operation of the maintenance script has failed, or produced undesired side effects, the script would purposefully *not* delete the `/var/maintenance-required` sentinel file on the host filesystem. Keeping that file around guarantees that this Kubernetes node will continue to be cordoned (not actively participating in the cluster); furthermore, it will guarantee that no other nodes will be negatively affected similarly (kustodian's "single node maintenance lock" will continue to be reserved by this node).
 
 Below is how a script might look that implements the kustodian daemonset specification:
 
 ```bash
 #!/bin/bash
 # if another script is already running on this host following the kustodian pattern, then wait
-until [ ! -f /var/run/maintenance-required ] && [ ! -f /var/run/maintenance-in-progress ]; do
+until [ ! -f /var/maintenance-required ] && [ ! -f /var/maintenance-in-progress ]; do
     echo "maintenance already in-progress, will wait";
     sleep 5;
 done;
 # request maintenance
-touch /var/run/maintenance-required;
+touch /var/maintenance-required;
 # wait until kustodian indicates that this node has been cordoned + drained, and exclusive maintenance reserved
-until test -f /var/run/maintenance-in-progress; do
+until test -f /var/maintenance-in-progress; do
     echo "waiting in the maintenance queue";
     sleep 5;
 done;
@@ -53,7 +53,7 @@ done;
 # perform maintenance
 # validate host health and expected outcomes
 # end maintenance
-rm -f /var/run/maintenance-required
+rm -f /var/maintenance-required
 ```
 
 ## Can I experiment with this now?

--- a/helm/kustodian/templates/kustodian.yaml
+++ b/helm/kustodian/templates/kustodian.yaml
@@ -110,13 +110,13 @@ spec:
             #            - --lock-annotation=k8s.io/kustodian-node-lock
             - --period=1m
             #            - --reboot-days=sun,mon,tue,wed,thu,fri,sat
-            #            - --maintenance-sentinel=/var/run/maintenance-required
+            #            - --maintenance-sentinel=/var/maintenance-required
             #            - --start-time=0:00
             #            - --time-zone=UTC
             - --annotate-nodes=true
           volumeMounts:
-            - name: var-run
-              mountPath: /var/run
+            - name: var
+              mountPath: /var
           resources:
             requests:
               cpu: 5m
@@ -126,7 +126,7 @@ spec:
               memory: 32Mi
       volumes:
         - hostPath:
-            path: /var/run
-          name: var-run
+            path: /var
+          name: var
       nodeSelector:
         kubernetes.io/os: linux

--- a/helm/mop/templates/mop.yaml
+++ b/helm/mop/templates/mop.yaml
@@ -21,18 +21,14 @@ spec:
             - sh
             - -c
             - >-
-              until [ ! -f /var/run/maintenance-required ] && [ ! -f /var/run/maintenance-in-progress ]; do
-                  echo "maintenance already in-progress, will wait";
-                  sleep 5;
-              done;
-              touch /var/run/maintenance-required;
-              until test -f /var/run/maintenance-in-progress; do
+              touch /var/maintenance-required;
+              until test -f /var/maintenance-in-progress; do
                   echo "waiting in the maintenance queue";
                   sleep 5;
               done;
           volumeMounts:
-            - name: var-run
-              mountPath: /var/run
+            - name: var
+              mountPath: /var
         - name: {{ .Values.mop.name }}-get-script
           image: curlimages/curl:latest
           imagePullPolicy: IfNotPresent
@@ -52,15 +48,15 @@ spec:
             - -c
             - >-
               chmod +x {{ .Values.mop.everyoneWriteablePath }}/mop-{{ .Values.mop.name }}.sh;
-              echo -e >/etc/cron.d/mop "* * * * * root sh -c 'rm -f /etc/cron.d/mop; {{ .Values.mop.everyoneWriteablePath }}/mop-{{ .Values.mop.name }}.sh && rm -f /var/run/maintenance-required' >/var/log/mop-{{ .Values.mop.name }}.log 2>&1";
+              echo -e >/etc/cron.d/mop "* * * * * root sh -c 'rm -f /etc/cron.d/mop; {{ .Values.mop.everyoneWriteablePath }}/mop-{{ .Values.mop.name }}.sh && rm -f /var/maintenance-required' >/var/log/mop-{{ .Values.mop.name }}.log 2>&1";
               until test -f /var/log/mop-{{ .Values.mop.name }}.log; do
                   echo "waiting for cron to execute {{ .Values.mop.everyoneWriteablePath }}/mop-{{ .Values.mop.name }}.sh"
                   sleep 5
               done;
               tail -f /var/log/mop-{{ .Values.mop.name }}.log;
           volumeMounts:
-            - name: var-run
-              mountPath: /var/run
+            - name: var
+              mountPath: /var
             - name: var-log
               mountPath: /var/log
             - name: node-crond
@@ -72,8 +68,8 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
         - hostPath:
-            path: /var/run
-          name: var-run
+            path: /var
+          name: var
         - hostPath:
             path: /var/log
           name: var-log


### PR DESCRIPTION
This PR changes the `/var/run/maintenance*` file paths to just `/var/run...` so that the state stored in those sentinel files can persist after a reboot (`/var/run` is conventionally mounted as tmpfs and garbage collected during a reboot).