### PR TITLE
Add apt-get upgrade example

### DIFF
--- a/examples/apt-get-upgrade.sh
+++ b/examples/apt-get-upgrade.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# assumes run as root
+export DEBIAN_FRONTEND=noninteractive
+wait_for_apt_locks() {
+  while fuser /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; do
+    echo 'Waiting for release of apt locks'
+    sleep 3
+  done
+}
+wait_for_reboot() {
+  while fuser /var/run/reboot-required >/dev/null 2>&1; do
+    echo 'Waiting for reboot'
+    sleep 3
+  done
+}
+wait_for_reboot
+wait_for_apt_locks
+dpkg --configure -a --force-confdef
+apt-get update
+wait_for_apt_locks
+apt-mark unhold $(apt-mark showhold | grep -v 'kube')
+apt-get upgrade -y
+wait_for_apt_locks
+apt-get upgrade -y $(apt-mark showmanual | grep -v 'kube')
+wait_for_apt_locks
+sleep 60 # wait a bit for apt to mark /var/run-reboot-required
+wait_for_reboot
+echo 'Exiting successfully'


### PR DESCRIPTION
This PR adds an apt-get upgrade example that is designed to be reboot-aware.