### PR TITLE
use new default image for kustodian chart

### DIFF
--- a/helm/kustodian/values.yaml
+++ b/helm/kustodian/values.yaml
@@ -5,4 +5,4 @@ kustodian:
   container:
     imageRegistry: docker.io
     imageRepository: jackfrancis/kustodian
-    imageTag: go-1.19-e8be0d8
+    imageTag: main-e374f46


### PR DESCRIPTION
This PR references a newer container image to use as default in the kustodian chart, based on recent updates.