### PR TITLE
Update default kustodian image to main-4308280

### DIFF
--- a/helm/kustodian/values.yaml
+++ b/helm/kustodian/values.yaml
@@ -5,4 +5,4 @@ kustodian:
   container:
     imageRegistry: docker.io
     imageRepository: jackfrancis/kustodian
-    imageTag: main-e374f46
+    imageTag: main-4308280


### PR DESCRIPTION
This PR updates the default kustodian image to the latest built from main