### PR TITLE
use non-deprecated nodeSelector API

### DIFF
--- a/helm/mop/templates/mop.yaml
+++ b/helm/mop/templates/mop.yaml
@@ -64,7 +64,7 @@ spec:
             - name: script-write-path
               mountPath: {{ .Values.mop.everyoneWriteablePath }}
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       terminationGracePeriodSeconds: 0
       volumes:
         - hostPath:


### PR DESCRIPTION
This PR updates the `nodeSelector` API usage in the `mop` reference chart to `kubernetes.io/os` (from the deprecated `beta.kubernetes.io/os`).

Fixes #24 