### PR TITLE
use docker/login-action@v2 and GITHUB_TOKEN for image push action

### DIFF
--- a/.github/workflows/build-and-test-kustodian-mop.yaml
+++ b/.github/workflows/build-and-test-kustodian-mop.yaml
@@ -28,11 +28,11 @@ jobs:
       - name: setup buildx
         uses: docker/setup-buildx-action@v1
       - name: login to GitHub container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: build and push
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
This PR updates the E2E github action to use the current best practice for pushing images to ghcr