### PR TITLE
use newer docker github action versions

### DIFF
--- a/.github/workflows/build-and-test-kustodian-mop.yaml
+++ b/.github/workflows/build-and-test-kustodian-mop.yaml
@@ -26,18 +26,18 @@ jobs:
         run: echo "RELEASE_VERSION=$(git rev-parse --short "$GITHUB_SHA")-canary" >> $GITHUB_ENV
         if: ${{github.event.inputs.image_tag == ''}}
       - name: setup buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: login to GitHub container registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: build and push
-        uses: docker/build-push-action@v2
+      - name: build image and push
+        uses: docker/build-push-action@v3
         with:
           push: true
-          file: cmd/kustodian/Dockerfile
+          context: cmd/kustodian/
           tags: |
             ghcr.io/jackfrancis/kustodian/kustodian:${{ env.RELEASE_VERSION }}
       - name: install go


### PR DESCRIPTION
This PR uses the latest releases of the `docker/setup-buildx-action` and `docker/build-push-action` GitHub Actions.