### PR TITLE
build kustodian before docker build

### DIFF
--- a/.github/workflows/build-and-test-kustodian-mop.yaml
+++ b/.github/workflows/build-and-test-kustodian-mop.yaml
@@ -25,6 +25,12 @@ jobs:
       - name: assign tag automatically based on current commit sha
         run: echo "RELEASE_VERSION=$(git rev-parse --short "$GITHUB_SHA")-canary" >> $GITHUB_ENV
         if: ${{github.event.inputs.image_tag == ''}}
+      - name: install go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^1.18'
+      - name: build kustodian binary
+        run: make cmd/kustodian/kustodian
       - name: setup buildx
         uses: docker/setup-buildx-action@v2
       - name: login to GitHub container registry
@@ -40,10 +46,6 @@ jobs:
           context: cmd/kustodian/
           tags: |
             ghcr.io/jackfrancis/kustodian/kustodian:${{ env.RELEASE_VERSION }}
-      - name: install go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '^1.18'
       - name: install helm
         run: |
           curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -


### PR DESCRIPTION
This PR ensures that we have a `kustodian` binary present in the `cmd/kustodian` directory before we build the container image in our E2E github action.