### PR TITLE
revert docker GithHub Actions

### DIFF
--- a/.github/workflows/build-and-test-kustodian-mop.yaml
+++ b/.github/workflows/build-and-test-kustodian-mop.yaml
@@ -34,16 +34,16 @@ jobs:
       - name: setup buildx
         uses: docker/setup-buildx-action@v2
       - name: login to GitHub container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: build image and push
-        uses: docker/build-push-action@v3
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      - name: build and push
+        uses: docker/build-push-action@v2
         with:
           push: true
-          context: cmd/kustodian/
+          file: cmd/kustodian/Dockerfile
           tags: |
             ghcr.io/jackfrancis/kustodian/kustodian:${{ env.RELEASE_VERSION }}
       - name: install helm


### PR DESCRIPTION
There may be a bug in the docker GitHub Actions @ the latest versions when pushing to ghcr, reverting.