### PR TITLE
incorporate reboot awareness into mop

### DIFF
--- a/examples/apt-get-upgrade.sh
+++ b/examples/apt-get-upgrade.sh
@@ -8,13 +8,6 @@ wait_for_apt_locks() {
     sleep 3
   done
 }
-wait_for_reboot() {
-  while fuser /var/run/reboot-required >/dev/null 2>&1; do
-    echo 'Waiting for reboot'
-    sleep 3
-  done
-}
-wait_for_reboot
 wait_for_apt_locks
 apt-get update
 wait_for_apt_locks
@@ -22,7 +15,3 @@ apt-mark unhold $(apt-mark showhold | grep -v 'kube')
 apt-get upgrade -y
 wait_for_apt_locks
 apt-get upgrade -y $(apt-mark showmanual | grep -v 'kube')
-wait_for_apt_locks
-sleep 60 # wait a bit for apt to mark /var/run-reboot-required
-wait_for_reboot
-echo 'Exiting successfully'

--- a/helm/mop/templates/mop.yaml
+++ b/helm/mop/templates/mop.yaml
@@ -21,6 +21,10 @@ spec:
             - sh
             - -c
             - >-
+              while fuser /var/run/reboot-required >/dev/null 2>&1; do
+                echo 'Reboot pending';
+                sleep 30;
+              done;
               touch /var/maintenance-required;
               until test -f /var/maintenance-in-progress; do
                 echo "waiting in the maintenance queue";
@@ -28,8 +32,8 @@ spec:
               done;
               until [[ "$READY" == "true" ]]; do
                 READY=true;
-                if ls /var/*.maintenance; then
-                  for filename in $(find /var/ -maxdepth 1 -name '*.maintenance'); do
+                if ls /var/run/*.maintenance; then
+                  for filename in $(find /var/run -maxdepth 1 -name '*.maintenance'); do
                     if [[ "$(basename $filename .maintenance)" -lte "{{.Values.mop.priority}}" ]]; then
                       READY=false;
                     fi
@@ -39,7 +43,7 @@ spec:
                   sleep 1;
                 fi
               done;
-              touch /var/{{.Values.mop.priority}}.maintenance;
+              touch /var/run/{{.Values.mop.priority}}.maintenance;
           volumeMounts:
             - name: var
               mountPath: /var
@@ -61,8 +65,12 @@ spec:
             - sh
             - -c
             - >-
+              while fuser /var/run/reboot-required >/dev/null 2>&1; do
+                echo 'Reboot pending';
+                sleep 30;
+              done;
               chmod +x {{ .Values.mop.everyoneWriteablePath }}/mop-{{ .Values.mop.name }}.sh;
-              echo -e >/etc/cron.d/mop "* * * * * root sh -c 'rm -f /etc/cron.d/mop; {{ .Values.mop.everyoneWriteablePath }}/mop-{{ .Values.mop.name }}.sh && rm -f /var/{{.Values.mop.priority}}.maintenance && sleep 5 && test -f /var/*.maintenance || rm -f /var/maintenance-required' >/var/log/mop-{{ .Values.mop.name }}.log 2>&1";
+              echo -e >/etc/cron.d/mop "* * * * * root sh -c 'rm -f /etc/cron.d/mop; {{ .Values.mop.everyoneWriteablePath }}/mop-{{ .Values.mop.name }}.sh && sleep 30; while fuser /var/run/reboot-required >/dev/null 2>&1; do sleep 3; done; echo {{ .Values.mop.name }} executed successfully; rm -f /var/run/{{.Values.mop.priority}}.maintenance && sleep 5 && test -f /var/run/*.maintenance || rm -f /var/maintenance-required' >/var/log/mop-{{ .Values.mop.name }}.log 2>&1";
               until test -f /var/log/mop-{{ .Values.mop.name }}.log; do
                   echo "waiting for cron to execute {{ .Values.mop.everyoneWriteablePath }}/mop-{{ .Values.mop.name }}.sh"
                   sleep 5


### PR DESCRIPTION
This PR ensures that a `mop` script doesn't proceed if we can detect that a pending reboot is needed, and that is doesn't mark maintenance as done until its successful execution (plus a 30 second wait) does not itself produce a need for a reboot. This ensures that we include a successful reboot into the `mop` script transaction.