### PR TITLE
add post-script validation to mop

### DIFF
--- a/examples/systemctl-validate.sh
+++ b/examples/systemctl-validate.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# assumes run as root
+if systemctl list-units | grep -i failed; then
+  exit 1
+fi
+exit 0

--- a/helm/mop/templates/mop.yaml
+++ b/helm/mop/templates/mop.yaml
@@ -55,6 +55,9 @@ spec:
             - -c
             - >-
               curl -fSL -o {{ .Values.mop.everyoneWriteablePath }}/mop-{{ .Values.mop.name }}.sh {{ .Values.mop.targetScript }};
+{{- if .Values.validation.enabled }}
+              curl -fSL -o {{ .Values.mop.everyoneWriteablePath }}/mop-{{ .Values.mop.name }}-validate.sh {{ .Values.mop.validationScript }};
+{{- end }}
           volumeMounts:
             - name: script-write-path
               mountPath: {{ .Values.mop.everyoneWriteablePath }}
@@ -70,7 +73,7 @@ spec:
                 sleep 30;
               done;
               chmod +x {{ .Values.mop.everyoneWriteablePath }}/mop-{{ .Values.mop.name }}.sh;
-              echo -e >/etc/cron.d/mop "* * * * * root sh -c 'rm -f /etc/cron.d/mop; {{ .Values.mop.everyoneWriteablePath }}/mop-{{ .Values.mop.name }}.sh && sleep 30; while fuser /var/run/reboot-required >/dev/null 2>&1; do sleep 3; done; echo {{ .Values.mop.name }} executed successfully; rm -f /var/run/{{.Values.mop.priority}}.maintenance && sleep 5 && test -f /var/run/*.maintenance || rm -f /var/maintenance-required' >/var/log/mop-{{ .Values.mop.name }}.log 2>&1";
+              echo -e >/etc/cron.d/mop "* * * * * root sh -c 'rm -f /etc/cron.d/mop; {{ .Values.mop.everyoneWriteablePath }}/mop-{{ .Values.mop.name }}.sh && sleep 30; while fuser /var/run/reboot-required >/dev/null 2>&1; do sleep 3; done; echo {{ .Values.mop.name }} executed successfully; {{if not .Values.validation.enabled }}rm -f /var/run/{{.Values.mop.priority}}.maintenance && sleep 5 && test -f /var/run/*.maintenance || rm -f /var/maintenance-required{{else}}touch /var/{{.Values.mop.priority}}.validation-required;{{end}}' >/var/log/mop-{{ .Values.mop.name }}.log 2>&1";
               until test -f /var/log/mop-{{ .Values.mop.name }}.log; do
                   echo "waiting for cron to execute {{ .Values.mop.everyoneWriteablePath }}/mop-{{ .Values.mop.name }}.sh"
                   sleep 5
@@ -85,6 +88,34 @@ spec:
               mountPath: /etc/cron.d
             - name: script-write-path
               mountPath: {{ .Values.mop.everyoneWriteablePath }}
+{{- if .Values.validation.enabled }}
+        - name: {{ .Values.mop.name }}-validate
+          image: alpine:3.16
+          command:
+            - sh
+            - -c
+            - >-
+              until test -f /var/{{.Values.mop.priority}}.validation-required; do
+                  echo "waiting for successful execution of {{ .Values.mop.everyoneWriteablePath }}/mop-{{ .Values.mop.name }}.sh"
+                  sleep 5
+              done;
+              chmod +x {{ .Values.mop.everyoneWriteablePath }}/mop-{{ .Values.mop.name }}-validate.sh;
+              echo -e >/etc/cron.d/mop-validate "* * * * * root sh -c 'rm -f /etc/cron.d/mop-validate; {{ .Values.mop.everyoneWriteablePath }}/mop-{{ .Values.mop.name }}-validate.sh && echo {{ .Values.mop.name }} validated successfully; rm -f /var/run/{{.Values.mop.priority}}.maintenance && sleep 5 && test -f /var/run/*.maintenance || rm -f /var/maintenance-required' >/var/log/mop-{{ .Values.mop.name }}-validate.log 2>&1";
+              until test -f /var/log/mop-{{ .Values.mop.name }}-validate.log; do
+                  echo "waiting for cron to execute {{ .Values.mop.everyoneWriteablePath }}/mop-{{ .Values.mop.name }}-vaidate.sh"
+                  sleep 5
+              done;
+              tail -f /var/log/mop-{{ .Values.mop.name }}-validate.log;
+          volumeMounts:
+            - name: var
+              mountPath: /var
+            - name: var-log
+              mountPath: /var/log
+            - name: node-crond
+              mountPath: /etc/cron.d
+            - name: script-write-path
+              mountPath: {{ .Values.mop.everyoneWriteablePath }}
+{{- end }}
       nodeSelector:
         kubernetes.io/os: linux
       terminationGracePeriodSeconds: 0

--- a/helm/mop/values.yaml
+++ b/helm/mop/values.yaml
@@ -3,5 +3,8 @@
 mop:
   name: mop
   targetScript: "https://raw.githubusercontent.com/jackfrancis/kustodian/main/examples/update-docker.sh"
+  validationScript: "https://raw.githubusercontent.com/jackfrancis/kustodian/main/examples/systemctl-validate.sh"
   everyoneWriteablePath: "/tmp"
   priority: "99"
+validation:
+  enabled: false


### PR DESCRIPTION
This PR adds post-script validation to the mop chart.

We indicate that we want to do post-script validation with the following boolean helm value option:

`helm install .... --set validation.enabled=true`

And then similar to the `mop.targetScript` value we pass in a `mop.validationScript` configuration:

`... --set mop.validationScript=https://raw.githubusercontent.com/jackfrancis/kustodian/11fecb2262119d765eb6e8b2cc8a970a0a999bed/examples/systemctl-validate.sh`

(Using `https://raw.githubusercontent.com/jackfrancis/kustodian/11fecb2262119d765eb6e8b2cc8a970a0a999bed/examples/systemctl-validate.sh` as an example publicly-accessible validation script in plain-text, above.)

If validation is not enabled, then the behavior is unchanged: we mark the node as out of service until the maintenance script exits successfully. If validation is enable, we mark the node as out of service until _both_ the maintenance script _and_ the validation scripts exit successfully, in that serial order.